### PR TITLE
Support container shorthand in matches pattern

### DIFF
--- a/test-that/src/assertions.rs
+++ b/test-that/src/assertions.rs
@@ -66,7 +66,7 @@
 ///     `verify_that!(actual, contains_exactly![m1, m2, ...])`
 #[macro_export]
 macro_rules! verify_that {
-    ($actual:expr, $($expected:tt)+ $(,)?) => {
+    ($actual:expr, $($expected:tt)+) => {
         $crate::assertions::internal::check_matcher(
             &$actual,
             $crate::__matcher_expr!($($expected)+),
@@ -85,7 +85,7 @@ macro_rules! __matcher_expr {
     ({$($expecteds:expr),* $(,)?}) => {
         $crate::matchers::containers::contains_exactly![$($expecteds),*]
     };
-    ($expected:expr) => { $expected };
+    ($expected:expr $(,)?) => { $expected };
 }
 
 /// Asserts that the given predicate applied to the given arguments returns

--- a/test-that/src/assertions.rs
+++ b/test-that/src/assertions.rs
@@ -66,30 +66,26 @@
 ///     `verify_that!(actual, contains_exactly![m1, m2, ...])`
 #[macro_export]
 macro_rules! verify_that {
-    ($actual:expr, [$($expecteds:expr),+ $(,)?]) => {
+    ($actual:expr, $($expected:tt)+ $(,)?) => {
         $crate::assertions::internal::check_matcher(
             &$actual,
-            $crate::matchers::containers::contains_exactly![$($expecteds),+].in_order(),
+            $crate::__matcher_expr!($($expected)+),
             stringify!($actual),
             $crate::internal::source_location::SourceLocation::new(file!(), line!(), column!()),
         )
     };
-    ($actual:expr, {$($expecteds:expr),+ $(,)?}) => {
-        $crate::assertions::internal::check_matcher(
-            &$actual,
-            $crate::matchers::containers::contains_exactly![$($expecteds),+],
-            stringify!($actual),
-            $crate::internal::source_location::SourceLocation::new(file!(), line!(), column!()),
-        )
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __matcher_expr {
+    ([$($expecteds:expr),* $(,)?]) => {
+        $crate::matchers::containers::contains_exactly![$($expecteds),*].in_order()
     };
-    ($actual:expr, $expected:expr $(,)?) => {
-        $crate::assertions::internal::check_matcher(
-            &$actual,
-            $expected,
-            stringify!($actual),
-            $crate::internal::source_location::SourceLocation::new(file!(), line!(), column!()),
-        )
+    ({$($expecteds:expr),* $(,)?}) => {
+        $crate::matchers::containers::contains_exactly![$($expecteds),*]
     };
+    ($expected:expr) => { $expected };
 }
 
 /// Asserts that the given predicate applied to the given arguments returns

--- a/test-that/src/matchers/matches_pattern.rs
+++ b/test-that/src/matchers/matches_pattern.rs
@@ -290,9 +290,9 @@
 ///
 /// ## Shorthand for matching against containers
 ///
-/// One can use the same `[...]` and `{...}` as in [`verify_that!`] and fields to match against
-/// containers. Use `[...]` to enforce order. This is equivalent to
-/// [`contains_exactly!`] with [`in_order()`].
+/// One can use the same `[...]` and `{...}` as in [`verify_that!`] and fields
+/// to match against containers. Use `[...]` to enforce order. This is
+/// equivalent to [`contains_exactly!`] with [`in_order()`].
 ///
 /// ```
 /// # use test_that::prelude::*;
@@ -308,7 +308,8 @@
 /// #    .unwrap();
 /// ```
 ///
-/// Use `{...}` to match elements in any order. This is equivalent to [`contains_exactly!`].
+/// Use `{...}` to match elements in any order. This is equivalent to
+/// [`contains_exactly!`].
 ///
 /// ```
 /// # use test_that::prelude::*;
@@ -368,8 +369,9 @@
 /// #    .unwrap();
 /// ```
 ///
-/// This shorthand notation works _only_ for direct arguments in the macro. If the container matcher
-/// is nested inside another matcher, one must use `contains_exactly!`.
+/// This shorthand notation works _only_ for direct arguments in the macro. If
+/// the container matcher is nested inside another matcher, one must use
+/// `contains_exactly!`.
 ///
 /// ```
 /// # use test_that::prelude::*;

--- a/test-that/src/matchers/matches_pattern.rs
+++ b/test-that/src/matchers/matches_pattern.rs
@@ -300,49 +300,63 @@ macro_rules! __matches_pattern {
 macro_rules! matches_pattern_internal {
     (
         [$($struct_name:tt)*],
-        { $field_name:ident : $matcher:expr $(,)? }
+        { $field_name:ident : {$($matcher:tt)*} $(,)? }
     ) => {
         $crate::matchers::__internal::is(
             stringify!($($struct_name)*),
-            $crate::matchers::all!($crate::matchers::field!($($struct_name)*.$field_name, $matcher))
-        )
-    };
-
-    (
-        [$($struct_name:tt)*],
-        { *$field_name:ident : $matcher:expr $(,)? }
-    ) => {
-        $crate::matchers::__internal::is(
-            stringify!($($struct_name)*),
-            $crate::matchers::all!($crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($matcher)))
-        )
-    };
-
-    (
-        [$($struct_name:tt)*],
-        { $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr $(,)? }
-    ) => {
-        $crate::matchers::__internal::is(
-            stringify!($($struct_name)*),
-            $crate::matchers::all!($crate::matchers::result_of!(
-                |s: &$($struct_name)*| s.$property_name($($argument),*),
-                $matcher,
+            $crate::matchers::all!($crate::matchers::field!(
+                $($struct_name)*.$field_name,
+                $crate::__matcher_expr!({$($matcher)*})
             ))
         )
     };
 
     (
         [$($struct_name:tt)*],
-        { * $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr $(,)? }
+        { $field_name:ident : {$($matcher:tt)*}, $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $crate::matchers::field!($($struct_name)*.$field_name, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        { $field_name:ident : [$($matcher:tt)*] $(,)? }
     ) => {
         $crate::matchers::__internal::is(
             stringify!($($struct_name)*),
+            $crate::matchers::all!($crate::matchers::field!(
+                $($struct_name)*.$field_name,
+                $crate::__matcher_expr!([$($matcher)*])
+            ))
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        { $field_name:ident : [$($matcher:tt)*], $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
             $crate::matchers::all!(
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::matchers::points_to($matcher),
-                )
-            )
+                $crate::matchers::field!($($struct_name)*.$field_name, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        { $field_name:ident : $matcher:expr $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!($crate::matchers::field!($($struct_name)*.$field_name, $matcher))
         )
     };
 
@@ -361,6 +375,77 @@ macro_rules! matches_pattern_internal {
 
     (
         [$($struct_name:tt)*],
+        { *$field_name:ident : {$($matcher:tt)*} $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!(
+                $crate::matchers::field!(
+                    $($struct_name)*.$field_name,
+                    $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*}))
+                )
+            )
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        { *$field_name:ident : {$($matcher:tt)*}, $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*})))
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        { *$field_name:ident : [$($matcher:tt)*] $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!(
+                $crate::matchers::field!(
+                    $($struct_name)*.$field_name,
+                    $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*]))
+                )
+            )
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        { *$field_name:ident : [$($matcher:tt)*], $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*])))
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        { *$field_name:ident : $matcher:expr $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!(
+                $crate::matchers::field!(
+                    $($struct_name)*.$field_name,
+                    $crate::matchers::points_to($matcher)
+                )
+            )
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
         { *$field_name:ident : $matcher:expr, $($rest:tt)* }
     ) => {
         $crate::matches_pattern_internal!(
@@ -369,6 +454,77 @@ macro_rules! matches_pattern_internal {
             ),
             [$($struct_name)*],
             { $($rest)* }
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        { $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*} $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!($crate::matchers::result_of!(
+                |s: &$($struct_name)*| s.$property_name($($argument),*),
+                $crate::__matcher_expr!({$($matcher)*}),
+            ))
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        { $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*}, $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $crate::matchers::result_of!(
+                    |s: &$($struct_name)*| s.$property_name($($argument),*),
+                    $crate::__matcher_expr!({$($matcher)*}),
+                )
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        { $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*] $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!($crate::matchers::result_of!(
+                |s: &$($struct_name)*| s.$property_name($($argument),*),
+                $crate::__matcher_expr!([$($matcher)*]),
+            ))
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        { $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*], $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $crate::matchers::result_of!(
+                    |s: &$($struct_name)*| s.$property_name($($argument),*),
+                    $crate::__matcher_expr!([$($matcher)*]),
+                )
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        { $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!($crate::matchers::result_of!(
+                |s: &$($struct_name)*| s.$property_name($($argument),*),
+                $matcher,
+            ))
         )
     };
 
@@ -385,6 +541,79 @@ macro_rules! matches_pattern_internal {
             ),
             [$($struct_name)*],
             { $($rest)* }
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        { * $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*} $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!($crate::matchers::result_of!(
+                |s: &$($struct_name)*| s.$property_name($($argument),*),
+                $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*})),
+            ))
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        { * $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*}, $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $crate::matchers::result_of!(
+                    |s: &$($struct_name)*| s.$property_name($($argument),*),
+                    $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*})),
+                )
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        { * $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*] $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!($crate::matchers::result_of!(
+                |s: &$($struct_name)*| s.$property_name($($argument),*),
+                $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*])),
+            ))
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        { * $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*], $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $crate::matchers::result_of!(
+                    |s: &$($struct_name)*| s.$property_name($($argument),*),
+                    $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*])),
+                )
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        { * $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!(
+                $crate::matchers::result_of!(
+                    |s: &$($struct_name)*| s.$property_name($($argument),*),
+                    $crate::matchers::points_to($matcher),
+                )
+            )
         )
     };
 
@@ -407,6 +636,64 @@ macro_rules! matches_pattern_internal {
     (
         $crate::matchers::all!($($processed:tt)*),
         [$($struct_name:tt)*],
+        { $field_name:ident : {$($matcher:tt)*} $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.$field_name, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        { $field_name:ident : {$($matcher:tt)*}, $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.$field_name, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        { $field_name:ident : [$($matcher:tt)*] $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.$field_name, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        { $field_name:ident : [$($matcher:tt)*], $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.$field_name, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
         { $field_name:ident : $matcher:expr $(,)? }
     ) => {
         $crate::matchers::__internal::is(
@@ -421,6 +708,79 @@ macro_rules! matches_pattern_internal {
     (
         $crate::matchers::all!($($processed:tt)*),
         [$($struct_name:tt)*],
+        { $field_name:ident : $matcher:expr, $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.$field_name, $matcher)
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        { *$field_name:ident : {$($matcher:tt)*} $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*})))
+            ),
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        { *$field_name:ident : {$($matcher:tt)*}, $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*})))
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        { *$field_name:ident : [$($matcher:tt)*] $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*])))
+            ),
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        { *$field_name:ident : [$($matcher:tt)*], $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*])))
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
         { *$field_name:ident : $matcher:expr $(,)? }
     ) => {
         $crate::matchers::__internal::is(
@@ -429,6 +789,91 @@ macro_rules! matches_pattern_internal {
                 $($processed)*,
                 $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($matcher))
             ),
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        { *$field_name:ident : $matcher:expr, $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($matcher))
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        { $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*} $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::result_of!(
+                    |s: &$($struct_name)*| s.$property_name($($argument),*),
+                    $crate::__matcher_expr!({$($matcher)*}),
+                )
+            ),
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        { $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*}, $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::result_of!(
+                    |s: &$($struct_name)*| s.$property_name($($argument),*),
+                    $crate::__matcher_expr!({$($matcher)*}),
+                )
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        { $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*] $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::result_of!(
+                    |s: &$($struct_name)*| s.$property_name($($argument),*),
+                    $crate::__matcher_expr!([$($matcher)*]),
+                )
+            ),
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        { $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*], $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::result_of!(
+                    |s: &$($struct_name)*| s.$property_name($($argument),*),
+                    $crate::__matcher_expr!([$($matcher)*]),
+                )
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
         )
     };
 
@@ -452,53 +897,6 @@ macro_rules! matches_pattern_internal {
     (
         $crate::matchers::all!($($processed:tt)*),
         [$($struct_name:tt)*],
-        { * $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr $(,)? }
-    ) => {
-        $crate::matchers::__internal::is(
-            stringify!($($struct_name)*),
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::matchers::points_to($matcher),
-                )
-            ),
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { $field_name:ident : $matcher:expr, $($rest:tt)* }
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.$field_name, $matcher)
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { *$field_name:ident : $matcher:expr, $($rest:tt)* }
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($matcher))
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
         { $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr, $($rest:tt)* }
     ) => {
         $crate::matches_pattern_internal!(
@@ -511,6 +909,93 @@ macro_rules! matches_pattern_internal {
             ),
             [$($struct_name)*],
             { $($rest)* }
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        { * $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*} $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::result_of!(
+                    |s: &$($struct_name)*| s.$property_name($($argument),*),
+                    $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*})),
+                )
+            ),
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        { * $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*}, $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::result_of!(
+                    |s: &$($struct_name)*| s.$property_name($($argument),*),
+                    $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*})),
+                )
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        { * $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*] $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::result_of!(
+                    |s: &$($struct_name)*| s.$property_name($($argument),*),
+                    $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*])),
+                )
+            ),
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        { * $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*], $($rest:tt)* }
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::result_of!(
+                    |s: &$($struct_name)*| s.$property_name($($argument),*),
+                    $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*])),
+                )
+            ),
+            [$($struct_name)*],
+            { $($rest)* }
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        { * $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr $(,)? }
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::result_of!(
+                    |s: &$($struct_name)*| s.$property_name($($argument),*),
+                    $crate::matchers::points_to($matcher),
+                )
+            ),
         )
     };
 
@@ -544,6 +1029,54 @@ macro_rules! matches_pattern_internal {
 
     (
         [$($struct_name:tt)*],
+        ({$($matcher:tt)*} $(,)?)
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!($crate::matchers::field!($($struct_name)*.0, $crate::__matcher_expr!({$($matcher)*})))
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        ({$($matcher:tt)*}, $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $crate::matchers::field!($($struct_name)*.0, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            1,
+            ($($rest)*)
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        ([$($matcher:tt)*] $(,)?)
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!($crate::matchers::field!($($struct_name)*.0, $crate::__matcher_expr!([$($matcher)*])))
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
+        ([$($matcher:tt)*], $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $crate::matchers::field!($($struct_name)*.0, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            1,
+            ($($rest)*)
+        )
+    };
+
+    (
+        [$($struct_name:tt)*],
         ($matcher:expr $(,)?)
     ) => {
         $crate::matchers::__internal::is(
@@ -570,6 +1103,314 @@ macro_rules! matches_pattern_internal {
         $crate::matchers::all!($($processed:tt)*),
         [$($struct_name:tt)*],
         $field:tt,
+        ({$($matcher:tt)*} $(,)?)
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.$field, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        $field:tt,
+        ([$($matcher:tt)*] $(,)?)
+    ) => {
+        $crate::matchers::__internal::is(
+            stringify!($($struct_name)*),
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.$field, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+        )
+    };
+
+    // We need to repeat this once for every supported field position, unfortunately. There appears
+    // to be no way in declarative macros to compute $field + 1 and have the result evaluated to a
+    // token which can be used as a tuple index.
+    //
+    // The {}/[] multi arms must come before the generic $expr last arm to avoid
+    // $expr committing to parsing {expr, expr} as a block expression and failing.
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        1,
+        ({$($matcher:tt)*}, $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.1, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            2,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        1,
+        ([$($matcher:tt)*], $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.1, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            2,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        2,
+        ({$($matcher:tt)*}, $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.2, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            3,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        2,
+        ([$($matcher:tt)*], $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.2, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            3,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        3,
+        ({$($matcher:tt)*}, $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.3, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            4,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        3,
+        ([$($matcher:tt)*], $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.3, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            4,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        4,
+        ({$($matcher:tt)*}, $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.4, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            5,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        4,
+        ([$($matcher:tt)*], $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.4, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            5,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        5,
+        ({$($matcher:tt)*}, $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.5, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            6,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        5,
+        ([$($matcher:tt)*], $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.5, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            6,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        6,
+        ({$($matcher:tt)*}, $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.6, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            7,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        6,
+        ([$($matcher:tt)*], $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.6, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            7,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        7,
+        ({$($matcher:tt)*}, $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.7, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            8,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        7,
+        ([$($matcher:tt)*], $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.7, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            8,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        8,
+        ({$($matcher:tt)*}, $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.8, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            9,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        8,
+        ([$($matcher:tt)*], $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.8, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            9,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        $field:tt,
         ($matcher:expr $(,)?)
     ) => {
         $crate::matchers::__internal::is(
@@ -581,9 +1422,6 @@ macro_rules! matches_pattern_internal {
         )
     };
 
-    // We need to repeat this once for every supported field position, unfortunately. There appears
-    // to be no way in declarative macros to compute $field + 1 and have the result evaluated to a
-    // token which can be used as a tuple index.
     (
         $crate::matchers::all!($($processed:tt)*),
         [$($struct_name:tt)*],
@@ -597,6 +1435,40 @@ macro_rules! matches_pattern_internal {
             ),
             [$($struct_name)*],
             2,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        2,
+        ({$($matcher:tt)*}, $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.2, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            3,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        2,
+        ([$($matcher:tt)*], $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.2, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            3,
             ($($rest)*)
         )
     };
@@ -622,6 +1494,40 @@ macro_rules! matches_pattern_internal {
         $crate::matchers::all!($($processed:tt)*),
         [$($struct_name:tt)*],
         3,
+        ({$($matcher:tt)*}, $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.3, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            4,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        3,
+        ([$($matcher:tt)*], $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.3, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            4,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        3,
         ($matcher:expr, $($rest:tt)*)
     ) => {
         $crate::matches_pattern_internal!(
@@ -631,6 +1537,40 @@ macro_rules! matches_pattern_internal {
             ),
             [$($struct_name)*],
             4,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        4,
+        ({$($matcher:tt)*}, $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.4, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            5,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        4,
+        ([$($matcher:tt)*], $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.4, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            5,
             ($($rest)*)
         )
     };
@@ -656,6 +1596,40 @@ macro_rules! matches_pattern_internal {
         $crate::matchers::all!($($processed:tt)*),
         [$($struct_name:tt)*],
         5,
+        ({$($matcher:tt)*}, $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.5, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            6,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        5,
+        ([$($matcher:tt)*], $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.5, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            6,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        5,
         ($matcher:expr, $($rest:tt)*)
     ) => {
         $crate::matches_pattern_internal!(
@@ -665,6 +1639,40 @@ macro_rules! matches_pattern_internal {
             ),
             [$($struct_name)*],
             6,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        6,
+        ({$($matcher:tt)*}, $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.6, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            7,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        6,
+        ([$($matcher:tt)*], $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.6, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            7,
             ($($rest)*)
         )
     };
@@ -690,6 +1698,40 @@ macro_rules! matches_pattern_internal {
         $crate::matchers::all!($($processed:tt)*),
         [$($struct_name:tt)*],
         7,
+        ({$($matcher:tt)*}, $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.7, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            8,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        7,
+        ([$($matcher:tt)*], $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.7, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            8,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        7,
         ($matcher:expr, $($rest:tt)*)
     ) => {
         $crate::matches_pattern_internal!(
@@ -699,6 +1741,40 @@ macro_rules! matches_pattern_internal {
             ),
             [$($struct_name)*],
             8,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        8,
+        ({$($matcher:tt)*}, $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.8, $crate::__matcher_expr!({$($matcher)*}))
+            ),
+            [$($struct_name)*],
+            9,
+            ($($rest)*)
+        )
+    };
+
+    (
+        $crate::matchers::all!($($processed:tt)*),
+        [$($struct_name:tt)*],
+        8,
+        ([$($matcher:tt)*], $($rest:tt)*)
+    ) => {
+        $crate::matches_pattern_internal!(
+            $crate::matchers::all!(
+                $($processed)*,
+                $crate::matchers::field!($($struct_name)*.8, $crate::__matcher_expr!([$($matcher)*]))
+            ),
+            [$($struct_name)*],
+            9,
             ($($rest)*)
         )
     };

--- a/test-that/src/matchers/matches_pattern.rs
+++ b/test-that/src/matchers/matches_pattern.rs
@@ -287,6 +287,107 @@
 ///
 /// Trailing commas are allowed (but not required) in both ordinary and tuple
 /// structs.
+///
+/// ## Shorthand for matching against containers
+///
+/// One can use the same `[...]` and `{...}` as in [`verify_that!`] and fields to match against
+/// containers. Use `[...]` to enforce order. This is equivalent to
+/// [`contains_exactly!`] with [`in_order()`].
+///
+/// ```
+/// # use test_that::prelude::*;
+/// #[derive(Debug)]
+/// struct MyStruct {
+///     a_vec: Vec<u32>,
+/// }
+///
+/// let my_struct = MyStruct { a_vec: vec![1, 2, 3] };
+/// verify_that!(my_struct, matches_pattern!(MyStruct {
+///     a_vec: [eq(1), gt(1), le(4)],
+/// }))
+/// #    .unwrap();
+/// ```
+///
+/// Use `{...}` to match elements in any order. This is equivalent to [`contains_exactly!`].
+///
+/// ```
+/// # use test_that::prelude::*;
+/// #[derive(Debug)]
+/// struct MyStruct {
+///     a_vec: Vec<u32>,
+/// }
+///
+/// let my_struct = MyStruct { a_vec: vec![1, 2, 3] };
+/// verify_that!(my_struct, matches_pattern!(MyStruct {
+///     a_vec: {eq(3), gt(1), eq(1)},
+/// }))
+/// #    .unwrap();
+/// ```
+///
+/// This works for both fields and properties.
+///
+/// ```
+/// # use test_that::prelude::*;
+/// #[derive(Debug)]
+/// struct MyStruct {
+///     a_vec: Vec<u32>,
+/// }
+///
+/// impl MyStruct {
+///     fn get_a_vec(&self) -> Vec<u32> {
+///         self.a_vec.clone()
+///     }
+/// }
+///
+/// let my_struct = MyStruct { a_vec: vec![1, 2, 3] };
+/// verify_that!(my_struct, matches_pattern!(MyStruct {
+///     get_a_vec(): [eq(1), gt(1), eq(3)],
+/// }))
+/// #    .unwrap();
+/// ```
+///
+/// It also works with the `*` notation for dereferencing a slice.
+///
+/// ```
+/// # use test_that::prelude::*;
+/// #[derive(Debug)]
+/// struct MyStruct {
+///     a_vec: Vec<u32>,
+/// }
+///
+/// impl MyStruct {
+///     fn get_a_slice(&self) -> &[u32] {
+///         &self.a_vec
+///     }
+/// }
+///
+/// let my_struct = MyStruct { a_vec: vec![1, 2, 3] };
+/// verify_that!(my_struct, matches_pattern!(MyStruct {
+///     *get_a_slice(): [eq(1), gt(1), eq(3)],
+/// }))
+/// #    .unwrap();
+/// ```
+///
+/// This shorthand notation works _only_ for direct arguments in the macro. If the container matcher
+/// is nested inside another matcher, one must use `contains_exactly!`.
+///
+/// ```
+/// # use test_that::prelude::*;
+/// #[derive(Debug)]
+/// struct MyStruct {
+///     maybe_a_vec: Option<Vec<u32>>,
+/// }
+///
+/// let my_struct = MyStruct { maybe_a_vec: Some(vec![1, 2, 3]) };
+/// verify_that!(my_struct, matches_pattern!(MyStruct {
+///     maybe_a_vec: some(contains_exactly![eq(1), gt(1), eq(3)].in_order()),
+/// }))
+/// #    .unwrap();
+/// ```
+///
+/// [`contains_exactly!`]: crate::matchers::containers::contains_exactly
+/// [`in_order()`]: crate::matchers::containers::ContainerContainsUnorderedMatcher::in_order
+/// [`verify_that!`]: crate::verify_that
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __matches_pattern {

--- a/test-that/src/matchers/matches_pattern.rs
+++ b/test-that/src/matchers/matches_pattern.rs
@@ -399,722 +399,184 @@ macro_rules! __matches_pattern {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! matches_pattern_internal {
-    (
-        [$($struct_name:tt)*],
-        { $field_name:ident : {$($matcher:tt)*} $(,)? }
-    ) => {
+    // Named struct fields: dispatch to @fwd accumulation.
+    // $first:tt requires at least one token, so empty {} falls through to the accumulator
+    // arm below, which handles patterns like AStruct {} (unit struct / enum variant).
+    ([$($struct_name:tt)*], { $first:tt $($rest:tt)* }) => {
+        $crate::matches_pattern_internal!(@fwd [], [$($struct_name)*], { $first $($rest)* })
+    };
+
+    // @fwd: accumulate named-struct field matchers one at a time.
+    // Within each field kind, {}/[] arms precede $expr to prevent $expr committing to
+    // {expr, expr} as a block expression (which would be a hard parse error).
+    // "Last" arms: field with optional trailing comma and nothing else; produce the result.
+    // "Multi" arms: field followed by $first:tt $($rest:tt)* (requires non-empty remainder).
+
+    // Regular field, {} matcher
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { $field_name:ident : {$($matcher:tt)*} $(,)? }) => {
         $crate::matchers::__internal::is(
             stringify!($($struct_name)*),
-            $crate::matchers::all!($crate::matchers::field!(
-                $($struct_name)*.$field_name,
-                $crate::__matcher_expr!({$($matcher)*})
-            ))
+            $crate::matchers::all!($($acc)* $crate::matchers::field!($($struct_name)*.$field_name, $crate::__matcher_expr!({$($matcher)*})),)
         )
     };
-
-    (
-        [$($struct_name:tt)*],
-        { $field_name:ident : {$($matcher:tt)*}, $($rest:tt)* }
-    ) => {
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { $field_name:ident : {$($matcher:tt)*}, $first:tt $($rest:tt)* }) => {
         $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $crate::matchers::field!($($struct_name)*.$field_name, $crate::__matcher_expr!({$($matcher)*}))
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
+            @fwd [$($acc)* $crate::matchers::field!($($struct_name)*.$field_name, $crate::__matcher_expr!({$($matcher)*})),],
+            [$($struct_name)*], { $first $($rest)* }
         )
     };
 
-    (
-        [$($struct_name:tt)*],
-        { $field_name:ident : [$($matcher:tt)*] $(,)? }
-    ) => {
+    // Regular field, [] matcher
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { $field_name:ident : [$($matcher:tt)*] $(,)? }) => {
         $crate::matchers::__internal::is(
             stringify!($($struct_name)*),
-            $crate::matchers::all!($crate::matchers::field!(
-                $($struct_name)*.$field_name,
-                $crate::__matcher_expr!([$($matcher)*])
-            ))
+            $crate::matchers::all!($($acc)* $crate::matchers::field!($($struct_name)*.$field_name, $crate::__matcher_expr!([$($matcher)*])),)
         )
     };
-
-    (
-        [$($struct_name:tt)*],
-        { $field_name:ident : [$($matcher:tt)*], $($rest:tt)* }
-    ) => {
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { $field_name:ident : [$($matcher:tt)*], $first:tt $($rest:tt)* }) => {
         $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $crate::matchers::field!($($struct_name)*.$field_name, $crate::__matcher_expr!([$($matcher)*]))
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
+            @fwd [$($acc)* $crate::matchers::field!($($struct_name)*.$field_name, $crate::__matcher_expr!([$($matcher)*])),],
+            [$($struct_name)*], { $first $($rest)* }
         )
     };
 
-    (
-        [$($struct_name:tt)*],
-        { $field_name:ident : $matcher:expr $(,)? }
-    ) => {
+    // Regular field, $expr matcher
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { $field_name:ident : $matcher:expr $(,)? }) => {
         $crate::matchers::__internal::is(
             stringify!($($struct_name)*),
-            $crate::matchers::all!($crate::matchers::field!($($struct_name)*.$field_name, $matcher))
+            $crate::matchers::all!($($acc)* $crate::matchers::field!($($struct_name)*.$field_name, $matcher),)
         )
     };
-
-    (
-        [$($struct_name:tt)*],
-        { $field_name:ident : $matcher:expr, $($rest:tt)* }
-    ) => {
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { $field_name:ident : $matcher:expr, $first:tt $($rest:tt)* }) => {
         $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $crate::matchers::field!($($struct_name)*.$field_name, $matcher)
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
+            @fwd [$($acc)* $crate::matchers::field!($($struct_name)*.$field_name, $matcher),],
+            [$($struct_name)*], { $first $($rest)* }
         )
     };
 
-    (
-        [$($struct_name:tt)*],
-        { *$field_name:ident : {$($matcher:tt)*} $(,)? }
-    ) => {
+    // Deref field, {} matcher
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { *$field_name:ident : {$($matcher:tt)*} $(,)? }) => {
         $crate::matchers::__internal::is(
             stringify!($($struct_name)*),
-            $crate::matchers::all!(
-                $crate::matchers::field!(
-                    $($struct_name)*.$field_name,
-                    $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*}))
-                )
-            )
+            $crate::matchers::all!($($acc)* $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*}))),)
         )
     };
-
-    (
-        [$($struct_name:tt)*],
-        { *$field_name:ident : {$($matcher:tt)*}, $($rest:tt)* }
-    ) => {
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { *$field_name:ident : {$($matcher:tt)*}, $first:tt $($rest:tt)* }) => {
         $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*})))
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
+            @fwd [$($acc)* $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*}))),],
+            [$($struct_name)*], { $first $($rest)* }
         )
     };
 
-    (
-        [$($struct_name:tt)*],
-        { *$field_name:ident : [$($matcher:tt)*] $(,)? }
-    ) => {
+    // Deref field, [] matcher
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { *$field_name:ident : [$($matcher:tt)*] $(,)? }) => {
         $crate::matchers::__internal::is(
             stringify!($($struct_name)*),
-            $crate::matchers::all!(
-                $crate::matchers::field!(
-                    $($struct_name)*.$field_name,
-                    $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*]))
-                )
-            )
+            $crate::matchers::all!($($acc)* $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*]))),)
         )
     };
-
-    (
-        [$($struct_name:tt)*],
-        { *$field_name:ident : [$($matcher:tt)*], $($rest:tt)* }
-    ) => {
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { *$field_name:ident : [$($matcher:tt)*], $first:tt $($rest:tt)* }) => {
         $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*])))
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
+            @fwd [$($acc)* $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*]))),],
+            [$($struct_name)*], { $first $($rest)* }
         )
     };
 
-    (
-        [$($struct_name:tt)*],
-        { *$field_name:ident : $matcher:expr $(,)? }
-    ) => {
+    // Deref field, $expr matcher
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { *$field_name:ident : $matcher:expr $(,)? }) => {
         $crate::matchers::__internal::is(
             stringify!($($struct_name)*),
-            $crate::matchers::all!(
-                $crate::matchers::field!(
-                    $($struct_name)*.$field_name,
-                    $crate::matchers::points_to($matcher)
-                )
-            )
+            $crate::matchers::all!($($acc)* $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($matcher)),)
         )
     };
-
-    (
-        [$($struct_name:tt)*],
-        { *$field_name:ident : $matcher:expr, $($rest:tt)* }
-    ) => {
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { *$field_name:ident : $matcher:expr, $first:tt $($rest:tt)* }) => {
         $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($matcher))
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
+            @fwd [$($acc)* $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($matcher)),],
+            [$($struct_name)*], { $first $($rest)* }
         )
     };
 
-    (
-        [$($struct_name:tt)*],
-        { $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*} $(,)? }
-    ) => {
+    // Property, {} matcher
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*} $(,)? }) => {
         $crate::matchers::__internal::is(
             stringify!($($struct_name)*),
-            $crate::matchers::all!($crate::matchers::result_of!(
-                |s: &$($struct_name)*| s.$property_name($($argument),*),
-                $crate::__matcher_expr!({$($matcher)*}),
-            ))
+            $crate::matchers::all!($($acc)* $crate::matchers::result_of!(|s: &$($struct_name)*| s.$property_name($($argument),*), $crate::__matcher_expr!({$($matcher)*}),),)
         )
     };
-
-    (
-        [$($struct_name:tt)*],
-        { $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*}, $($rest:tt)* }
-    ) => {
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*}, $first:tt $($rest:tt)* }) => {
         $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::__matcher_expr!({$($matcher)*}),
-                )
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
+            @fwd [$($acc)* $crate::matchers::result_of!(|s: &$($struct_name)*| s.$property_name($($argument),*), $crate::__matcher_expr!({$($matcher)*}),),],
+            [$($struct_name)*], { $first $($rest)* }
         )
     };
 
-    (
-        [$($struct_name:tt)*],
-        { $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*] $(,)? }
-    ) => {
+    // Property, [] matcher
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*] $(,)? }) => {
         $crate::matchers::__internal::is(
             stringify!($($struct_name)*),
-            $crate::matchers::all!($crate::matchers::result_of!(
-                |s: &$($struct_name)*| s.$property_name($($argument),*),
-                $crate::__matcher_expr!([$($matcher)*]),
-            ))
+            $crate::matchers::all!($($acc)* $crate::matchers::result_of!(|s: &$($struct_name)*| s.$property_name($($argument),*), $crate::__matcher_expr!([$($matcher)*]),),)
         )
     };
-
-    (
-        [$($struct_name:tt)*],
-        { $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*], $($rest:tt)* }
-    ) => {
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*], $first:tt $($rest:tt)* }) => {
         $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::__matcher_expr!([$($matcher)*]),
-                )
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
+            @fwd [$($acc)* $crate::matchers::result_of!(|s: &$($struct_name)*| s.$property_name($($argument),*), $crate::__matcher_expr!([$($matcher)*]),),],
+            [$($struct_name)*], { $first $($rest)* }
         )
     };
 
-    (
-        [$($struct_name:tt)*],
-        { $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr $(,)? }
-    ) => {
+    // Property, $expr matcher
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr $(,)? }) => {
         $crate::matchers::__internal::is(
             stringify!($($struct_name)*),
-            $crate::matchers::all!($crate::matchers::result_of!(
-                |s: &$($struct_name)*| s.$property_name($($argument),*),
-                $matcher,
-            ))
+            $crate::matchers::all!($($acc)* $crate::matchers::result_of!(|s: &$($struct_name)*| s.$property_name($($argument),*), $matcher,),)
         )
     };
-
-    (
-        [$($struct_name:tt)*],
-        { $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr, $($rest:tt)* }
-    ) => {
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr, $first:tt $($rest:tt)* }) => {
         $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $matcher,
-                )
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
+            @fwd [$($acc)* $crate::matchers::result_of!(|s: &$($struct_name)*| s.$property_name($($argument),*), $matcher,),],
+            [$($struct_name)*], { $first $($rest)* }
         )
     };
 
-    (
-        [$($struct_name:tt)*],
-        { * $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*} $(,)? }
-    ) => {
+    // Deref property, {} matcher
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { * $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*} $(,)? }) => {
         $crate::matchers::__internal::is(
             stringify!($($struct_name)*),
-            $crate::matchers::all!($crate::matchers::result_of!(
-                |s: &$($struct_name)*| s.$property_name($($argument),*),
-                $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*})),
-            ))
+            $crate::matchers::all!($($acc)* $crate::matchers::result_of!(|s: &$($struct_name)*| s.$property_name($($argument),*), $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*})),),)
         )
     };
-
-    (
-        [$($struct_name:tt)*],
-        { * $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*}, $($rest:tt)* }
-    ) => {
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { * $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*}, $first:tt $($rest:tt)* }) => {
         $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*})),
-                )
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
+            @fwd [$($acc)* $crate::matchers::result_of!(|s: &$($struct_name)*| s.$property_name($($argument),*), $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*})),),],
+            [$($struct_name)*], { $first $($rest)* }
         )
     };
 
-    (
-        [$($struct_name:tt)*],
-        { * $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*] $(,)? }
-    ) => {
+    // Deref property, [] matcher
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { * $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*] $(,)? }) => {
         $crate::matchers::__internal::is(
             stringify!($($struct_name)*),
-            $crate::matchers::all!($crate::matchers::result_of!(
-                |s: &$($struct_name)*| s.$property_name($($argument),*),
-                $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*])),
-            ))
+            $crate::matchers::all!($($acc)* $crate::matchers::result_of!(|s: &$($struct_name)*| s.$property_name($($argument),*), $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*])),),)
         )
     };
-
-    (
-        [$($struct_name:tt)*],
-        { * $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*], $($rest:tt)* }
-    ) => {
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { * $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*], $first:tt $($rest:tt)* }) => {
         $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*])),
-                )
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
+            @fwd [$($acc)* $crate::matchers::result_of!(|s: &$($struct_name)*| s.$property_name($($argument),*), $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*])),),],
+            [$($struct_name)*], { $first $($rest)* }
         )
     };
 
-    (
-        [$($struct_name:tt)*],
-        { * $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr $(,)? }
-    ) => {
+    // Deref property, $expr matcher
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { * $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr $(,)? }) => {
         $crate::matchers::__internal::is(
             stringify!($($struct_name)*),
-            $crate::matchers::all!(
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::matchers::points_to($matcher),
-                )
-            )
+            $crate::matchers::all!($($acc)* $crate::matchers::result_of!(|s: &$($struct_name)*| s.$property_name($($argument),*), $crate::matchers::points_to($matcher),),)
         )
     };
-
-    (
-        [$($struct_name:tt)*],
-        { * $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr, $($rest:tt)* }
-    ) => {
+    (@fwd [$($acc:tt)*], [$($struct_name:tt)*], { * $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr, $first:tt $($rest:tt)* }) => {
         $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::matchers::points_to($matcher),
-                )
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { $field_name:ident : {$($matcher:tt)*} $(,)? }
-    ) => {
-        $crate::matchers::__internal::is(
-            stringify!($($struct_name)*),
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.$field_name, $crate::__matcher_expr!({$($matcher)*}))
-            ),
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { $field_name:ident : {$($matcher:tt)*}, $($rest:tt)* }
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.$field_name, $crate::__matcher_expr!({$($matcher)*}))
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { $field_name:ident : [$($matcher:tt)*] $(,)? }
-    ) => {
-        $crate::matchers::__internal::is(
-            stringify!($($struct_name)*),
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.$field_name, $crate::__matcher_expr!([$($matcher)*]))
-            ),
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { $field_name:ident : [$($matcher:tt)*], $($rest:tt)* }
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.$field_name, $crate::__matcher_expr!([$($matcher)*]))
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { $field_name:ident : $matcher:expr $(,)? }
-    ) => {
-        $crate::matchers::__internal::is(
-            stringify!($($struct_name)*),
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.$field_name, $matcher)
-            ),
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { $field_name:ident : $matcher:expr, $($rest:tt)* }
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.$field_name, $matcher)
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { *$field_name:ident : {$($matcher:tt)*} $(,)? }
-    ) => {
-        $crate::matchers::__internal::is(
-            stringify!($($struct_name)*),
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*})))
-            ),
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { *$field_name:ident : {$($matcher:tt)*}, $($rest:tt)* }
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*})))
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { *$field_name:ident : [$($matcher:tt)*] $(,)? }
-    ) => {
-        $crate::matchers::__internal::is(
-            stringify!($($struct_name)*),
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*])))
-            ),
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { *$field_name:ident : [$($matcher:tt)*], $($rest:tt)* }
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*])))
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { *$field_name:ident : $matcher:expr $(,)? }
-    ) => {
-        $crate::matchers::__internal::is(
-            stringify!($($struct_name)*),
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($matcher))
-            ),
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { *$field_name:ident : $matcher:expr, $($rest:tt)* }
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.$field_name, $crate::matchers::points_to($matcher))
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*} $(,)? }
-    ) => {
-        $crate::matchers::__internal::is(
-            stringify!($($struct_name)*),
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::__matcher_expr!({$($matcher)*}),
-                )
-            ),
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*}, $($rest:tt)* }
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::__matcher_expr!({$($matcher)*}),
-                )
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*] $(,)? }
-    ) => {
-        $crate::matchers::__internal::is(
-            stringify!($($struct_name)*),
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::__matcher_expr!([$($matcher)*]),
-                )
-            ),
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*], $($rest:tt)* }
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::__matcher_expr!([$($matcher)*]),
-                )
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr $(,)? }
-    ) => {
-        $crate::matchers::__internal::is(
-            stringify!($($struct_name)*),
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $matcher,
-                )
-            ),
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr, $($rest:tt)* }
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $matcher,
-                )
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { * $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*} $(,)? }
-    ) => {
-        $crate::matchers::__internal::is(
-            stringify!($($struct_name)*),
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*})),
-                )
-            ),
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { * $property_name:ident($($argument:expr),* $(,)?) : {$($matcher:tt)*}, $($rest:tt)* }
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::matchers::points_to($crate::__matcher_expr!({$($matcher)*})),
-                )
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { * $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*] $(,)? }
-    ) => {
-        $crate::matchers::__internal::is(
-            stringify!($($struct_name)*),
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*])),
-                )
-            ),
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { * $property_name:ident($($argument:expr),* $(,)?) : [$($matcher:tt)*], $($rest:tt)* }
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::matchers::points_to($crate::__matcher_expr!([$($matcher)*])),
-                )
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { * $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr $(,)? }
-    ) => {
-        $crate::matchers::__internal::is(
-            stringify!($($struct_name)*),
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::matchers::points_to($matcher),
-                )
-            ),
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        { * $property_name:ident($($argument:expr),* $(,)?) : $matcher:expr, $($rest:tt)* }
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::result_of!(
-                    |s: &$($struct_name)*| s.$property_name($($argument),*),
-                    $crate::matchers::points_to($matcher),
-                )
-            ),
-            [$($struct_name)*],
-            { $($rest)* }
+            @fwd [$($acc)* $crate::matchers::result_of!(|s: &$($struct_name)*| s.$property_name($($argument),*), $crate::matchers::points_to($matcher),),],
+            [$($struct_name)*], { $first $($rest)* }
         )
     };
 
@@ -1544,40 +1006,6 @@ macro_rules! matches_pattern_internal {
         $crate::matchers::all!($($processed:tt)*),
         [$($struct_name:tt)*],
         2,
-        ({$($matcher:tt)*}, $($rest:tt)*)
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.2, $crate::__matcher_expr!({$($matcher)*}))
-            ),
-            [$($struct_name)*],
-            3,
-            ($($rest)*)
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        2,
-        ([$($matcher:tt)*], $($rest:tt)*)
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.2, $crate::__matcher_expr!([$($matcher)*]))
-            ),
-            [$($struct_name)*],
-            3,
-            ($($rest)*)
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        2,
         ($matcher:expr, $($rest:tt)*)
     ) => {
         $crate::matches_pattern_internal!(
@@ -1587,40 +1015,6 @@ macro_rules! matches_pattern_internal {
             ),
             [$($struct_name)*],
             3,
-            ($($rest)*)
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        3,
-        ({$($matcher:tt)*}, $($rest:tt)*)
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.3, $crate::__matcher_expr!({$($matcher)*}))
-            ),
-            [$($struct_name)*],
-            4,
-            ($($rest)*)
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        3,
-        ([$($matcher:tt)*], $($rest:tt)*)
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.3, $crate::__matcher_expr!([$($matcher)*]))
-            ),
-            [$($struct_name)*],
-            4,
             ($($rest)*)
         )
     };
@@ -1646,40 +1040,6 @@ macro_rules! matches_pattern_internal {
         $crate::matchers::all!($($processed:tt)*),
         [$($struct_name:tt)*],
         4,
-        ({$($matcher:tt)*}, $($rest:tt)*)
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.4, $crate::__matcher_expr!({$($matcher)*}))
-            ),
-            [$($struct_name)*],
-            5,
-            ($($rest)*)
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        4,
-        ([$($matcher:tt)*], $($rest:tt)*)
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.4, $crate::__matcher_expr!([$($matcher)*]))
-            ),
-            [$($struct_name)*],
-            5,
-            ($($rest)*)
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        4,
         ($matcher:expr, $($rest:tt)*)
     ) => {
         $crate::matches_pattern_internal!(
@@ -1689,40 +1049,6 @@ macro_rules! matches_pattern_internal {
             ),
             [$($struct_name)*],
             5,
-            ($($rest)*)
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        5,
-        ({$($matcher:tt)*}, $($rest:tt)*)
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.5, $crate::__matcher_expr!({$($matcher)*}))
-            ),
-            [$($struct_name)*],
-            6,
-            ($($rest)*)
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        5,
-        ([$($matcher:tt)*], $($rest:tt)*)
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.5, $crate::__matcher_expr!([$($matcher)*]))
-            ),
-            [$($struct_name)*],
-            6,
             ($($rest)*)
         )
     };
@@ -1748,40 +1074,6 @@ macro_rules! matches_pattern_internal {
         $crate::matchers::all!($($processed:tt)*),
         [$($struct_name:tt)*],
         6,
-        ({$($matcher:tt)*}, $($rest:tt)*)
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.6, $crate::__matcher_expr!({$($matcher)*}))
-            ),
-            [$($struct_name)*],
-            7,
-            ($($rest)*)
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        6,
-        ([$($matcher:tt)*], $($rest:tt)*)
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.6, $crate::__matcher_expr!([$($matcher)*]))
-            ),
-            [$($struct_name)*],
-            7,
-            ($($rest)*)
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        6,
         ($matcher:expr, $($rest:tt)*)
     ) => {
         $crate::matches_pattern_internal!(
@@ -1799,40 +1091,6 @@ macro_rules! matches_pattern_internal {
         $crate::matchers::all!($($processed:tt)*),
         [$($struct_name:tt)*],
         7,
-        ({$($matcher:tt)*}, $($rest:tt)*)
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.7, $crate::__matcher_expr!({$($matcher)*}))
-            ),
-            [$($struct_name)*],
-            8,
-            ($($rest)*)
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        7,
-        ([$($matcher:tt)*], $($rest:tt)*)
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.7, $crate::__matcher_expr!([$($matcher)*]))
-            ),
-            [$($struct_name)*],
-            8,
-            ($($rest)*)
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        7,
         ($matcher:expr, $($rest:tt)*)
     ) => {
         $crate::matches_pattern_internal!(
@@ -1842,40 +1100,6 @@ macro_rules! matches_pattern_internal {
             ),
             [$($struct_name)*],
             8,
-            ($($rest)*)
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        8,
-        ({$($matcher:tt)*}, $($rest:tt)*)
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.8, $crate::__matcher_expr!({$($matcher)*}))
-            ),
-            [$($struct_name)*],
-            9,
-            ($($rest)*)
-        )
-    };
-
-    (
-        $crate::matchers::all!($($processed:tt)*),
-        [$($struct_name:tt)*],
-        8,
-        ([$($matcher:tt)*], $($rest:tt)*)
-    ) => {
-        $crate::matches_pattern_internal!(
-            $crate::matchers::all!(
-                $($processed)*,
-                $crate::matchers::field!($($struct_name)*.8, $crate::__matcher_expr!([$($matcher)*]))
-            ),
-            [$($struct_name)*],
-            9,
             ($($rest)*)
         )
     };

--- a/test-that/tests/matches_pattern_test.rs
+++ b/test-that/tests/matches_pattern_test.rs
@@ -2188,7 +2188,7 @@ fn matches_method_returning_slice_with_shorthand_set_syntax() -> TestResult<()> 
     verify_that!(actual, matches_pattern!(AStruct { *get_a_slice(): {eq(3), eq(2), eq(1)} }))
 }
 
-// ── Container shorthand in multi-field structs ────────────────────────────────
+// Container shorthand in multi-field structs
 
 #[test]
 fn shorthand_array_syntax_in_first_position_of_two_fields() -> TestResult<()> {
@@ -2414,7 +2414,7 @@ fn deref_property_shorthand_set_syntax_in_first_position_of_two_fields() -> Test
     )
 }
 
-// ── Trailing comma ────────────────────────────────────────────────────────────
+// Trailing comma
 
 #[test]
 #[rustfmt::skip]
@@ -2496,7 +2496,7 @@ fn shorthand_set_syntax_without_trailing_comma_in_last_of_two_fields() -> TestRe
     )
 }
 
-// ── Empty container shorthand ─────────────────────────────────────────────────
+// Empty container shorthand
 
 #[test]
 fn empty_array_shorthand_matches_empty_vec() -> TestResult<()> {
@@ -2558,13 +2558,10 @@ fn empty_array_shorthand_in_first_of_two_fields_matches_empty_vec() -> TestResul
 
     let actual = AStruct { a_vec: vec![], another_field: 42 };
 
-    verify_that!(
-        actual,
-        matches_pattern!(AStruct { a_vec: [], another_field: eq(42) })
-    )
+    verify_that!(actual, matches_pattern!(AStruct { a_vec: [], another_field: eq(42) }))
 }
 
-// ── Tuple structs ─────────────────────────────────────────────────────────────
+// Tuple structs
 
 #[test]
 fn tuple_struct_single_element_with_shorthand_array_syntax() -> TestResult<()> {
@@ -2633,10 +2630,7 @@ fn tuple_struct_middle_element_of_three_with_shorthand_array_syntax() -> TestRes
 
     let actual = ATupleStruct(10, vec![1, 2, 3], 20);
 
-    verify_that!(
-        actual,
-        matches_pattern!(ATupleStruct(eq(10), [eq(1), eq(2), eq(3)], eq(20)))
-    )
+    verify_that!(actual, matches_pattern!(ATupleStruct(eq(10), [eq(1), eq(2), eq(3)], eq(20))))
 }
 
 #[test]
@@ -2646,10 +2640,7 @@ fn tuple_struct_middle_element_of_three_with_shorthand_set_syntax() -> TestResul
 
     let actual = ATupleStruct(10, vec![1, 2, 3], 20);
 
-    verify_that!(
-        actual,
-        matches_pattern!(ATupleStruct(eq(10), {eq(3), eq(1), eq(2)}, eq(20)))
-    )
+    verify_that!(actual, matches_pattern!(ATupleStruct(eq(10), {eq(3), eq(1), eq(2)}, eq(20))))
 }
 
 #[test]
@@ -2732,4 +2723,46 @@ fn enum_tuple_variant_empty_array_shorthand_matches_empty_vec() -> TestResult<()
     let actual = AnEnum::A(vec![]);
 
     verify_that!(actual, matches_pattern!(AnEnum::A([])))
+}
+
+#[test]
+fn ordered_container_shorthand_notation_works_in_nested_matcher() -> TestResult<()> {
+    #[derive(Debug)]
+    struct InnerStruct {
+        vec: Vec<u32>,
+    }
+    #[derive(Debug)]
+    struct OuterStruct {
+        inner: InnerStruct,
+    }
+
+    let actual = OuterStruct { inner: InnerStruct { vec: vec![1, 2, 3] } };
+
+    verify_that!(
+        actual,
+        matches_pattern!(OuterStruct { inner: pat!(InnerStruct { vec: [eq(1), eq(2), eq(3)] }) })
+    )
+}
+
+#[test]
+fn unordered_container_shorthand_notation_works_in_nested_matcher() -> TestResult<()> {
+    #[derive(Debug)]
+    struct InnerStruct {
+        vec: Vec<u32>,
+    }
+    #[derive(Debug)]
+    struct OuterStruct {
+        inner: InnerStruct,
+    }
+
+    let actual = OuterStruct { inner: InnerStruct { vec: vec![1, 2, 3] } };
+
+    verify_that!(
+        actual,
+        matches_pattern!(OuterStruct {
+            inner: pat!(InnerStruct {
+                vec: {eq(3), eq(2), eq(1)},
+            })
+        })
+    )
 }

--- a/test-that/tests/matches_pattern_test.rs
+++ b/test-that/tests/matches_pattern_test.rs
@@ -2069,3 +2069,667 @@ fn matches_method_returning_array_slice_with_points_to_for_single_element() -> T
         })
     )
 }
+
+#[test]
+fn matches_vec_field_with_shorthand_array_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+    }
+
+    let actual = AStruct { a_vec: vec![1, 2, 3] };
+
+    verify_that!(actual, matches_pattern!(AStruct { a_vec: [eq(1), eq(2), eq(3)] }))
+}
+
+#[test]
+fn matches_vec_field_with_shorthand_set_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+    }
+
+    let actual = AStruct { a_vec: vec![1, 2, 3] };
+
+    verify_that!(actual, matches_pattern!(AStruct { a_vec: {eq(3), eq(2), eq(1)} }))
+}
+
+#[test]
+fn matches_slice_field_with_shorthand_array_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct<'a> {
+        a_slice: &'a [u32],
+    }
+
+    let value = vec![1, 2, 3];
+    let actual = AStruct { a_slice: &value };
+
+    verify_that!(actual, matches_pattern!(AStruct { *a_slice: [eq(1), eq(2), eq(3)] }))
+}
+
+#[test]
+fn matches_slice_field_with_shorthand_set_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct<'a> {
+        a_slice: &'a [u32],
+    }
+
+    let value = vec![1, 2, 3];
+    let actual = AStruct { a_slice: &value };
+
+    verify_that!(actual, matches_pattern!(AStruct { *a_slice: {eq(3), eq(2), eq(1)} }))
+}
+
+#[test]
+fn matches_method_returning_vec_with_shorthand_array_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+    }
+    impl AStruct {
+        fn get_a_vec(&self) -> Vec<u32> {
+            self.a_vec.clone()
+        }
+    }
+
+    let actual = AStruct { a_vec: vec![1, 2, 3] };
+
+    verify_that!(actual, matches_pattern!(AStruct { get_a_vec(): [eq(1), eq(2), eq(3)] }))
+}
+
+#[test]
+fn matches_method_returning_vec_with_shorthand_set_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+    }
+    impl AStruct {
+        fn get_a_vec(&self) -> Vec<u32> {
+            self.a_vec.clone()
+        }
+    }
+
+    let actual = AStruct { a_vec: vec![1, 2, 3] };
+
+    verify_that!(actual, matches_pattern!(AStruct { get_a_vec(): {eq(3), eq(2), eq(1)} }))
+}
+
+#[test]
+fn matches_method_returning_slice_with_shorthand_array_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+    }
+    impl AStruct {
+        fn get_a_slice(&self) -> &[u32] {
+            &self.a_vec
+        }
+    }
+
+    let actual = AStruct { a_vec: vec![1, 2, 3] };
+
+    verify_that!(actual, matches_pattern!(AStruct { *get_a_slice(): [eq(1), eq(2), eq(3)] }))
+}
+
+#[test]
+fn matches_method_returning_slice_with_shorthand_set_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+    }
+    impl AStruct {
+        fn get_a_slice(&self) -> &[u32] {
+            &self.a_vec
+        }
+    }
+
+    let actual = AStruct { a_vec: vec![1, 2, 3] };
+
+    verify_that!(actual, matches_pattern!(AStruct { *get_a_slice(): {eq(3), eq(2), eq(1)} }))
+}
+
+// ── Container shorthand in multi-field structs ────────────────────────────────
+
+#[test]
+fn shorthand_array_syntax_in_first_position_of_two_fields() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+        another_field: u32,
+    }
+
+    let actual = AStruct { a_vec: vec![1, 2, 3], another_field: 42 };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct { a_vec: [eq(1), eq(2), eq(3)], another_field: eq(42) })
+    )
+}
+
+#[test]
+fn shorthand_set_syntax_in_first_position_of_two_fields() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+        another_field: u32,
+    }
+
+    let actual = AStruct { a_vec: vec![1, 2, 3], another_field: 42 };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct { a_vec: {eq(3), eq(1), eq(2)}, another_field: eq(42) })
+    )
+}
+
+#[test]
+fn shorthand_array_syntax_in_middle_position_of_three_fields() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        first_field: u32,
+        a_vec: Vec<u32>,
+        last_field: u32,
+    }
+
+    let actual = AStruct { first_field: 10, a_vec: vec![1, 2, 3], last_field: 20 };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct {
+            first_field: eq(10),
+            a_vec: [eq(1), eq(2), eq(3)],
+            last_field: eq(20)
+        })
+    )
+}
+
+#[test]
+fn shorthand_set_syntax_in_middle_position_of_three_fields() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        first_field: u32,
+        a_vec: Vec<u32>,
+        last_field: u32,
+    }
+
+    let actual = AStruct { first_field: 10, a_vec: vec![1, 2, 3], last_field: 20 };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct {
+            first_field: eq(10),
+            a_vec: {eq(3), eq(1), eq(2)},
+            last_field: eq(20)
+        })
+    )
+}
+
+#[test]
+fn shorthand_array_syntax_in_last_position_of_two_fields() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        another_field: u32,
+        a_vec: Vec<u32>,
+    }
+
+    let actual = AStruct { another_field: 42, a_vec: vec![1, 2, 3] };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct { another_field: eq(42), a_vec: [eq(1), eq(2), eq(3)] })
+    )
+}
+
+#[test]
+fn shorthand_set_syntax_in_last_position_of_two_fields() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        another_field: u32,
+        a_vec: Vec<u32>,
+    }
+
+    let actual = AStruct { another_field: 42, a_vec: vec![1, 2, 3] };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct { another_field: eq(42), a_vec: {eq(3), eq(1), eq(2)} })
+    )
+}
+
+#[test]
+fn deref_field_shorthand_array_syntax_in_first_position_of_two_fields() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct<'a> {
+        a_slice: &'a [u32],
+        another_field: u32,
+    }
+
+    let value = vec![1, 2, 3];
+    let actual = AStruct { a_slice: &value, another_field: 42 };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct { *a_slice: [eq(1), eq(2), eq(3)], another_field: eq(42) })
+    )
+}
+
+#[test]
+fn deref_field_shorthand_set_syntax_in_first_position_of_two_fields() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct<'a> {
+        a_slice: &'a [u32],
+        another_field: u32,
+    }
+
+    let value = vec![1, 2, 3];
+    let actual = AStruct { a_slice: &value, another_field: 42 };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct { *a_slice: {eq(3), eq(1), eq(2)}, another_field: eq(42) })
+    )
+}
+
+#[test]
+fn property_shorthand_array_syntax_in_first_position_of_two_fields() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+        another_field: u32,
+    }
+    impl AStruct {
+        fn get_a_vec(&self) -> Vec<u32> {
+            self.a_vec.clone()
+        }
+    }
+
+    let actual = AStruct { a_vec: vec![1, 2, 3], another_field: 42 };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct { get_a_vec(): [eq(1), eq(2), eq(3)], another_field: eq(42) })
+    )
+}
+
+#[test]
+fn property_shorthand_set_syntax_in_first_position_of_two_fields() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+        another_field: u32,
+    }
+    impl AStruct {
+        fn get_a_vec(&self) -> Vec<u32> {
+            self.a_vec.clone()
+        }
+    }
+
+    let actual = AStruct { a_vec: vec![1, 2, 3], another_field: 42 };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct { get_a_vec(): {eq(3), eq(1), eq(2)}, another_field: eq(42) })
+    )
+}
+
+#[test]
+fn deref_property_shorthand_array_syntax_in_first_position_of_two_fields() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+        another_field: u32,
+    }
+    impl AStruct {
+        fn get_a_slice(&self) -> &[u32] {
+            &self.a_vec
+        }
+    }
+
+    let actual = AStruct { a_vec: vec![1, 2, 3], another_field: 42 };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct { *get_a_slice(): [eq(1), eq(2), eq(3)], another_field: eq(42) })
+    )
+}
+
+#[test]
+fn deref_property_shorthand_set_syntax_in_first_position_of_two_fields() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+        another_field: u32,
+    }
+    impl AStruct {
+        fn get_a_slice(&self) -> &[u32] {
+            &self.a_vec
+        }
+    }
+
+    let actual = AStruct { a_vec: vec![1, 2, 3], another_field: 42 };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct { *get_a_slice(): {eq(3), eq(1), eq(2)}, another_field: eq(42) })
+    )
+}
+
+// ── Trailing comma ────────────────────────────────────────────────────────────
+
+#[test]
+#[rustfmt::skip]
+fn shorthand_array_syntax_with_trailing_comma_in_first_of_two_fields() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+        another_field: u32,
+    }
+
+    let actual = AStruct { a_vec: vec![1, 2, 3], another_field: 42 };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct {
+            a_vec: [eq(1), eq(2), eq(3),],
+            another_field: eq(42),
+        })
+    )
+}
+
+#[test]
+#[rustfmt::skip]
+fn shorthand_set_syntax_with_trailing_comma_in_first_of_two_fields() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+        another_field: u32,
+    }
+
+    let actual = AStruct { a_vec: vec![1, 2, 3], another_field: 42 };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct {
+            a_vec: {eq(3), eq(1), eq(2),},
+            another_field: eq(42),
+        })
+    )
+}
+
+#[test]
+#[rustfmt::skip]
+fn shorthand_array_syntax_without_trailing_comma_in_last_of_two_fields() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        another_field: u32,
+        a_vec: Vec<u32>,
+    }
+
+    let actual = AStruct { another_field: 42, a_vec: vec![1, 2, 3] };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct {
+            another_field: eq(42),
+            a_vec: [eq(1), eq(2), eq(3)]
+        })
+    )
+}
+
+#[test]
+#[rustfmt::skip]
+fn shorthand_set_syntax_without_trailing_comma_in_last_of_two_fields() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        another_field: u32,
+        a_vec: Vec<u32>,
+    }
+
+    let actual = AStruct { another_field: 42, a_vec: vec![1, 2, 3] };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct {
+            another_field: eq(42),
+            a_vec: {eq(3), eq(1), eq(2)}
+        })
+    )
+}
+
+// ── Empty container shorthand ─────────────────────────────────────────────────
+
+#[test]
+fn empty_array_shorthand_matches_empty_vec() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+    }
+
+    let actual = AStruct { a_vec: vec![] };
+
+    verify_that!(actual, matches_pattern!(AStruct { a_vec: [] }))
+}
+
+#[test]
+fn empty_set_shorthand_matches_empty_vec() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+    }
+
+    let actual = AStruct { a_vec: vec![] };
+
+    verify_that!(actual, matches_pattern!(AStruct { a_vec: {} }))
+}
+
+#[test]
+#[rustfmt::skip]
+fn empty_array_shorthand_with_trailing_comma_matches_empty_vec() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+    }
+
+    let actual = AStruct { a_vec: vec![] };
+
+    verify_that!(actual, matches_pattern!(AStruct { a_vec: [,] }))
+}
+
+#[test]
+#[rustfmt::skip]
+fn empty_set_shorthand_with_trailing_comma_matches_empty_vec() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+    }
+
+    let actual = AStruct { a_vec: vec![] };
+
+    verify_that!(actual, matches_pattern!(AStruct { a_vec: {,} }))
+}
+
+#[test]
+fn empty_array_shorthand_in_first_of_two_fields_matches_empty_vec() -> TestResult<()> {
+    #[derive(Debug)]
+    struct AStruct {
+        a_vec: Vec<u32>,
+        another_field: u32,
+    }
+
+    let actual = AStruct { a_vec: vec![], another_field: 42 };
+
+    verify_that!(
+        actual,
+        matches_pattern!(AStruct { a_vec: [], another_field: eq(42) })
+    )
+}
+
+// ── Tuple structs ─────────────────────────────────────────────────────────────
+
+#[test]
+fn tuple_struct_single_element_with_shorthand_array_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    struct ATupleStruct(Vec<u32>);
+
+    let actual = ATupleStruct(vec![1, 2, 3]);
+
+    verify_that!(actual, matches_pattern!(ATupleStruct([eq(1), eq(2), eq(3)])))
+}
+
+#[test]
+fn tuple_struct_single_element_with_shorthand_set_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    struct ATupleStruct(Vec<u32>);
+
+    let actual = ATupleStruct(vec![1, 2, 3]);
+
+    verify_that!(actual, matches_pattern!(ATupleStruct({eq(3), eq(1), eq(2)})))
+}
+
+#[test]
+fn tuple_struct_first_element_of_two_with_shorthand_array_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    struct ATupleStruct(Vec<u32>, u32);
+
+    let actual = ATupleStruct(vec![1, 2, 3], 42);
+
+    verify_that!(actual, matches_pattern!(ATupleStruct([eq(1), eq(2), eq(3)], eq(42))))
+}
+
+#[test]
+fn tuple_struct_first_element_of_two_with_shorthand_set_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    struct ATupleStruct(Vec<u32>, u32);
+
+    let actual = ATupleStruct(vec![1, 2, 3], 42);
+
+    verify_that!(actual, matches_pattern!(ATupleStruct({eq(3), eq(1), eq(2)}, eq(42))))
+}
+
+#[test]
+fn tuple_struct_last_element_of_two_with_shorthand_array_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    struct ATupleStruct(u32, Vec<u32>);
+
+    let actual = ATupleStruct(42, vec![1, 2, 3]);
+
+    verify_that!(actual, matches_pattern!(ATupleStruct(eq(42), [eq(1), eq(2), eq(3)])))
+}
+
+#[test]
+fn tuple_struct_last_element_of_two_with_shorthand_set_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    struct ATupleStruct(u32, Vec<u32>);
+
+    let actual = ATupleStruct(42, vec![1, 2, 3]);
+
+    verify_that!(actual, matches_pattern!(ATupleStruct(eq(42), {eq(3), eq(1), eq(2)})))
+}
+
+#[test]
+fn tuple_struct_middle_element_of_three_with_shorthand_array_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    struct ATupleStruct(u32, Vec<u32>, u32);
+
+    let actual = ATupleStruct(10, vec![1, 2, 3], 20);
+
+    verify_that!(
+        actual,
+        matches_pattern!(ATupleStruct(eq(10), [eq(1), eq(2), eq(3)], eq(20)))
+    )
+}
+
+#[test]
+fn tuple_struct_middle_element_of_three_with_shorthand_set_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    struct ATupleStruct(u32, Vec<u32>, u32);
+
+    let actual = ATupleStruct(10, vec![1, 2, 3], 20);
+
+    verify_that!(
+        actual,
+        matches_pattern!(ATupleStruct(eq(10), {eq(3), eq(1), eq(2)}, eq(20)))
+    )
+}
+
+#[test]
+fn tuple_struct_single_element_empty_array_shorthand_matches_empty_vec() -> TestResult<()> {
+    #[derive(Debug)]
+    struct ATupleStruct(Vec<u32>);
+
+    let actual = ATupleStruct(vec![]);
+
+    verify_that!(actual, matches_pattern!(ATupleStruct([])))
+}
+
+#[test]
+fn tuple_struct_single_element_empty_set_shorthand_matches_empty_vec() -> TestResult<()> {
+    #[derive(Debug)]
+    struct ATupleStruct(Vec<u32>);
+
+    let actual = ATupleStruct(vec![]);
+
+    verify_that!(actual, matches_pattern!(ATupleStruct({})))
+}
+
+// ── Enums ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn enum_tuple_variant_single_element_with_shorthand_array_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    enum AnEnum {
+        A(Vec<u32>),
+    }
+
+    let actual = AnEnum::A(vec![1, 2, 3]);
+
+    verify_that!(actual, matches_pattern!(AnEnum::A([eq(1), eq(2), eq(3)])))
+}
+
+#[test]
+fn enum_tuple_variant_single_element_with_shorthand_set_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    enum AnEnum {
+        A(Vec<u32>),
+    }
+
+    let actual = AnEnum::A(vec![1, 2, 3]);
+
+    verify_that!(actual, matches_pattern!(AnEnum::A({eq(3), eq(1), eq(2)})))
+}
+
+#[test]
+fn enum_tuple_variant_first_element_of_two_with_shorthand_array_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    enum AnEnum {
+        A(Vec<u32>, u32),
+    }
+
+    let actual = AnEnum::A(vec![1, 2, 3], 42);
+
+    verify_that!(actual, matches_pattern!(AnEnum::A([eq(1), eq(2), eq(3)], eq(42))))
+}
+
+#[test]
+fn enum_tuple_variant_last_element_of_two_with_shorthand_array_syntax() -> TestResult<()> {
+    #[derive(Debug)]
+    enum AnEnum {
+        A(u32, Vec<u32>),
+    }
+
+    let actual = AnEnum::A(42, vec![1, 2, 3]);
+
+    verify_that!(actual, matches_pattern!(AnEnum::A(eq(42), [eq(1), eq(2), eq(3)])))
+}
+
+#[test]
+fn enum_tuple_variant_empty_array_shorthand_matches_empty_vec() -> TestResult<()> {
+    #[derive(Debug)]
+    enum AnEnum {
+        A(Vec<u32>),
+    }
+
+    let actual = AnEnum::A(vec![]);
+
+    verify_that!(actual, matches_pattern!(AnEnum::A([])))
+}


### PR DESCRIPTION
This allows the same shorthand syntax in `matches_pattern!` as one can do with `verify_that!` and friends:

```rust
verify_that!(value, matches_pattern!(MyStruct {
    a_vec: [eq(1), eq(2), eq(3)],
    a_set: {eq(3), eq(2), eq(1)},
])
```

Just adding this feature bloats the macro by a factor of three. So this also rewrites the `matches_pattern!` to reduce the bloat somewhat. The functionality should not be affected -- as evidenced by the tests, which are pretty thorough.